### PR TITLE
replace URI.encode with another method

### DIFF
--- a/kubernetes/lib/kubernetes/api_client.rb
+++ b/kubernetes/lib/kubernetes/api_client.rb
@@ -264,7 +264,7 @@ module Kubernetes
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI.encode_www_form(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/kubernetes/lib/kubernetes/configuration.rb
+++ b/kubernetes/lib/kubernetes/configuration.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require 'uri'
+require 'cgi'
 
 module Kubernetes
   class Configuration
@@ -175,7 +175,7 @@ module Kubernetes
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      CGI.escape(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
Ruby3ではURI.encodeが使えなくなったため修正する


## 修正の元ネタ
  - https://github.com/kubernetes-client/ruby/compare/master...joshsouza:kubernetes-client-ruby:master

入力パターンを考えると、処理としては問題なさそう

## 補足
- CGI.escape: https://docs.ruby-lang.org/ja/latest/method/CGI/s/escape.html
- URI.encode_www_form: https://docs.ruby-lang.org/ja/latest/method/URI/s/encode_www_form.html 
