### PR TITLE
replace URI.encode to URI.encode_www_form_component

### DIFF
--- a/kubernetes/lib/kubernetes/api_client.rb
+++ b/kubernetes/lib/kubernetes/api_client.rb
@@ -264,7 +264,7 @@ module Kubernetes
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI.encode_www_form_component(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/kubernetes/lib/kubernetes/configuration.rb
+++ b/kubernetes/lib/kubernetes/configuration.rb
@@ -175,7 +175,7 @@ module Kubernetes
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI.encode_www_form_component(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
- `URI.encode` is obsolete in Ruby 3
- replace to `URI.encode_www_form_component`
  - ref: https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string