### PR TITLE
Revert "replace URI.encode to URI.encode_www_form_component"

### DIFF
--- a/kubernetes/lib/kubernetes/api_client.rb
+++ b/kubernetes/lib/kubernetes/api_client.rb
@@ -264,7 +264,7 @@ module Kubernetes
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode_www_form_component(@config.base_url + path)
+      URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/kubernetes/lib/kubernetes/configuration.rb
+++ b/kubernetes/lib/kubernetes/configuration.rb
@@ -175,7 +175,7 @@ module Kubernetes
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode_www_form_component(url)
+      URI.encode(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
Reverts primenumber-dev/kubernetes-client-ruby#2

`URI.encode_www_form_component` is not same as `URI.encode`

```
irb(main):046:0> URI.encode_www_form_component("https://")
=> "https%3A%2F%2F"
irb(main):047:0> URI.encode("https://")
(irb):47: warning: URI.escape is obsolete
=> "https://"
```