### PR TITLE
remove URI.escape and escape paths

### DIFF
--- a/kubernetes/Gemfile.lock
+++ b/kubernetes/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     kubernetes-io (1.0.0.pre.alpha2)
-      json (~> 2.1, >= 2.1.0)
+      json (~> 2.6, >= 2.6.3)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM
@@ -23,10 +23,10 @@ GEM
     diff-lcs (1.3)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.10.0)
+    ffi (1.15.5)
     hashdiff (0.3.9)
     jaro_winkler (1.5.2)
-    json (2.1.0)
+    json (2.6.3)
     parallel (1.14.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
@@ -35,6 +35,7 @@ GEM
     public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (13.0.1)
+    rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -80,10 +81,11 @@ DEPENDENCIES
   autotest-rails-pure (~> 4.1, >= 4.1.2)
   kubernetes-io!
   rake (~> 13.0.1)
+  rexml (~> 3.2, >= 3.2.4)
   rspec (~> 3.6, >= 3.6.0)
   rubocop (~> 0.65.0)
   vcr (~> 3.0, >= 3.0.1)
   webmock (~> 3.5.1)
 
 BUNDLED WITH
-   2.0.1
+   2.2.33

--- a/kubernetes/kubernetes.gemspec
+++ b/kubernetes/kubernetes.gemspec
@@ -28,11 +28,12 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'json', '~> 2.6', '>= 2.6.3'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
   s.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.3'
+  s.add_development_dependency 'rexml', '~> 3.2', '>= 3.2.4'
   s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'

--- a/kubernetes/lib/kubernetes/api/admissionregistration_api.rb
+++ b/kubernetes/lib/kubernetes/api/admissionregistration_api.rb
@@ -10,8 +10,6 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
-
 module Kubernetes
   class AdmissionregistrationApi
     attr_accessor :api_client

--- a/kubernetes/lib/kubernetes/api/admissionregistration_v1alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/admissionregistration_v1alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AdmissionregistrationV1alpha1Api
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AdmissionregistrationV1alpha1Api.delete_initializer_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AdmissionregistrationV1alpha1Api.patch_initializer_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -454,7 +454,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AdmissionregistrationV1alpha1Api.read_initializer_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -522,7 +522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AdmissionregistrationV1alpha1Api.replace_initializer_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/admissionregistration_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/admissionregistration_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AdmissionregistrationV1beta1Api
@@ -336,7 +336,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AdmissionregistrationV1beta1Api.delete_mutating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -408,7 +408,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AdmissionregistrationV1beta1Api.delete_validating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -679,7 +679,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AdmissionregistrationV1beta1Api.patch_mutating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -746,7 +746,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AdmissionregistrationV1beta1Api.patch_validating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -809,7 +809,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AdmissionregistrationV1beta1Api.read_mutating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -873,7 +873,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AdmissionregistrationV1beta1Api.read_validating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -941,7 +941,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AdmissionregistrationV1beta1Api.replace_mutating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1008,7 +1008,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AdmissionregistrationV1beta1Api.replace_validating_webhook_configuration"
       end
       # resource path
-      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/apiextensions_api.rb
+++ b/kubernetes/lib/kubernetes/api/apiextensions_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ApiextensionsApi

--- a/kubernetes/lib/kubernetes/api/apiextensions_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/apiextensions_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ApiextensionsV1beta1Api
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiextensionsV1beta1Api.delete_custom_resource_definition"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiextensionsV1beta1Api.patch_custom_resource_definition"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -458,7 +458,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiextensionsV1beta1Api.patch_custom_resource_definition_status"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -521,7 +521,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiextensionsV1beta1Api.read_custom_resource_definition"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -581,7 +581,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiextensionsV1beta1Api.read_custom_resource_definition_status"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -647,7 +647,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiextensionsV1beta1Api.replace_custom_resource_definition"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -714,7 +714,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiextensionsV1beta1Api.replace_custom_resource_definition_status"
       end
       # resource path
-      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/apiregistration_api.rb
+++ b/kubernetes/lib/kubernetes/api/apiregistration_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ApiregistrationApi

--- a/kubernetes/lib/kubernetes/api/apiregistration_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/apiregistration_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ApiregistrationV1Api
@@ -120,7 +120,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiregistrationV1Api.delete_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1Api.patch_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -458,7 +458,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1Api.patch_api_service_status"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -521,7 +521,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiregistrationV1Api.read_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -581,7 +581,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiregistrationV1Api.read_api_service_status"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -647,7 +647,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1Api.replace_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -714,7 +714,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1Api.replace_api_service_status"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1/apiservices/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/apiregistration_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/apiregistration_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ApiregistrationV1beta1Api
@@ -120,7 +120,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiregistrationV1beta1Api.delete_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1beta1Api.patch_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -458,7 +458,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1beta1Api.patch_api_service_status"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -521,7 +521,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiregistrationV1beta1Api.read_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -581,7 +581,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ApiregistrationV1beta1Api.read_api_service_status"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -647,7 +647,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1beta1Api.replace_api_service"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -714,7 +714,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ApiregistrationV1beta1Api.replace_api_service_status"
       end
       # resource path
-      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/apiregistration.k8s.io/v1beta1/apiservices/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/apis_api.rb
+++ b/kubernetes/lib/kubernetes/api/apis_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ApisApi

--- a/kubernetes/lib/kubernetes/api/apps_api.rb
+++ b/kubernetes/lib/kubernetes/api/apps_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AppsApi

--- a/kubernetes/lib/kubernetes/api/apps_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/apps_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AppsV1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.create_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -126,7 +126,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.create_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.create_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -266,7 +266,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.create_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -336,7 +336,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.create_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -412,7 +412,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_collection_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -494,7 +494,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_collection_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -576,7 +576,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_collection_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -658,7 +658,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_collection_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -740,7 +740,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_collection_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -822,7 +822,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -900,7 +900,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -978,7 +978,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1056,7 +1056,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1134,7 +1134,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.delete_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1489,7 +1489,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.list_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1571,7 +1571,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.list_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1653,7 +1653,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.list_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1735,7 +1735,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.list_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1817,7 +1817,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.list_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2049,7 +2049,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2122,7 +2122,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2195,7 +2195,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2268,7 +2268,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2341,7 +2341,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2414,7 +2414,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2487,7 +2487,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2560,7 +2560,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2633,7 +2633,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2706,7 +2706,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2779,7 +2779,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2852,7 +2852,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.patch_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2921,7 +2921,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2991,7 +2991,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3057,7 +3057,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3125,7 +3125,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3191,7 +3191,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3255,7 +3255,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3323,7 +3323,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3389,7 +3389,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3453,7 +3453,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3521,7 +3521,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3587,7 +3587,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3651,7 +3651,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1Api.read_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3723,7 +3723,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3796,7 +3796,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3869,7 +3869,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3942,7 +3942,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4015,7 +4015,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4088,7 +4088,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4161,7 +4161,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4234,7 +4234,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4307,7 +4307,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4380,7 +4380,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4453,7 +4453,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4526,7 +4526,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1Api.replace_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/apps_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/apps_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AppsV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.create_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -126,7 +126,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.create_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -202,7 +202,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.create_namespaced_deployment_rollback"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/rollback".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/rollback".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -272,7 +272,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.create_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -348,7 +348,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.delete_collection_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -430,7 +430,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.delete_collection_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -512,7 +512,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.delete_collection_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -594,7 +594,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.delete_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -672,7 +672,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.delete_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -750,7 +750,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.delete_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1029,7 +1029,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.list_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1111,7 +1111,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.list_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1193,7 +1193,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.list_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1349,7 +1349,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1422,7 +1422,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1495,7 +1495,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1568,7 +1568,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1641,7 +1641,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1714,7 +1714,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1787,7 +1787,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.patch_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1856,7 +1856,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1926,7 +1926,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1992,7 +1992,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2056,7 +2056,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2124,7 +2124,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2190,7 +2190,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2254,7 +2254,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta1Api.read_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2326,7 +2326,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2399,7 +2399,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2472,7 +2472,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2545,7 +2545,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2618,7 +2618,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2691,7 +2691,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2764,7 +2764,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta1Api.replace_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/apps_v1beta2_api.rb
+++ b/kubernetes/lib/kubernetes/api/apps_v1beta2_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AppsV1beta2Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.create_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -126,7 +126,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.create_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.create_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -266,7 +266,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.create_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -336,7 +336,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.create_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -412,7 +412,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_collection_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -494,7 +494,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_collection_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -576,7 +576,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_collection_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -658,7 +658,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_collection_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -740,7 +740,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_collection_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -822,7 +822,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -900,7 +900,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -978,7 +978,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1056,7 +1056,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1134,7 +1134,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.delete_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1489,7 +1489,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.list_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1571,7 +1571,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.list_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1653,7 +1653,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.list_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1735,7 +1735,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.list_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1817,7 +1817,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.list_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2049,7 +2049,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2122,7 +2122,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2195,7 +2195,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2268,7 +2268,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2341,7 +2341,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2414,7 +2414,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2487,7 +2487,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2560,7 +2560,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2633,7 +2633,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2706,7 +2706,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2779,7 +2779,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2852,7 +2852,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.patch_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2921,7 +2921,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2991,7 +2991,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3057,7 +3057,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3125,7 +3125,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3191,7 +3191,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3255,7 +3255,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3323,7 +3323,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3389,7 +3389,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3453,7 +3453,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3521,7 +3521,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3587,7 +3587,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3651,7 +3651,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AppsV1beta2Api.read_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3723,7 +3723,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_controller_revision"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/controllerrevisions/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3796,7 +3796,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3869,7 +3869,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3942,7 +3942,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4015,7 +4015,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4088,7 +4088,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4161,7 +4161,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4234,7 +4234,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4307,7 +4307,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4380,7 +4380,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_stateful_set"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4453,7 +4453,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_stateful_set_scale"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4526,7 +4526,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AppsV1beta2Api.replace_namespaced_stateful_set_status"
       end
       # resource path
-      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/apps/v1beta2/namespaces/{namespace}/statefulsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/auditregistration_api.rb
+++ b/kubernetes/lib/kubernetes/api/auditregistration_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuditregistrationApi

--- a/kubernetes/lib/kubernetes/api/auditregistration_v1alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/auditregistration_v1alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuditregistrationV1alpha1Api
@@ -120,7 +120,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AuditregistrationV1alpha1Api.delete_audit_sink"
       end
       # resource path
-      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AuditregistrationV1alpha1Api.patch_audit_sink"
       end
       # resource path
-      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -454,7 +454,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling AuditregistrationV1alpha1Api.read_audit_sink"
       end
       # resource path
-      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -522,7 +522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AuditregistrationV1alpha1Api.replace_audit_sink"
       end
       # resource path
-      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/auditregistration.k8s.io/v1alpha1/auditsinks/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/authentication_api.rb
+++ b/kubernetes/lib/kubernetes/api/authentication_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuthenticationApi

--- a/kubernetes/lib/kubernetes/api/authentication_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/authentication_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuthenticationV1Api

--- a/kubernetes/lib/kubernetes/api/authentication_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/authentication_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuthenticationV1beta1Api

--- a/kubernetes/lib/kubernetes/api/authorization_api.rb
+++ b/kubernetes/lib/kubernetes/api/authorization_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuthorizationApi

--- a/kubernetes/lib/kubernetes/api/authorization_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/authorization_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuthorizationV1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AuthorizationV1Api.create_namespaced_local_subject_access_review"
       end
       # resource path
-      local_var_path = "/apis/authorization.k8s.io/v1/namespaces/{namespace}/localsubjectaccessreviews".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/authorization.k8s.io/v1/namespaces/{namespace}/localsubjectaccessreviews".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/authorization_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/authorization_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AuthorizationV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AuthorizationV1beta1Api.create_namespaced_local_subject_access_review"
       end
       # resource path
-      local_var_path = "/apis/authorization.k8s.io/v1beta1/namespaces/{namespace}/localsubjectaccessreviews".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/authorization.k8s.io/v1beta1/namespaces/{namespace}/localsubjectaccessreviews".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/autoscaling_api.rb
+++ b/kubernetes/lib/kubernetes/api/autoscaling_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AutoscalingApi

--- a/kubernetes/lib/kubernetes/api/autoscaling_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/autoscaling_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AutoscalingV1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV1Api.create_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV1Api.delete_collection_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV1Api.delete_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV1Api.list_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV1Api.patch_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -570,7 +570,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV1Api.patch_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -639,7 +639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV1Api.read_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -705,7 +705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV1Api.read_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -777,7 +777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV1Api.replace_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -850,7 +850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV1Api.replace_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/autoscaling_v2beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/autoscaling_v2beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AutoscalingV2beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta1Api.create_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta1Api.delete_collection_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta1Api.delete_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta1Api.list_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta1Api.patch_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -570,7 +570,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta1Api.patch_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -639,7 +639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta1Api.read_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -705,7 +705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta1Api.read_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -777,7 +777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta1Api.replace_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -850,7 +850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta1Api.replace_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/autoscaling_v2beta2_api.rb
+++ b/kubernetes/lib/kubernetes/api/autoscaling_v2beta2_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class AutoscalingV2beta2Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta2Api.create_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta2Api.delete_collection_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta2Api.delete_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta2Api.list_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta2Api.patch_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -570,7 +570,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta2Api.patch_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -639,7 +639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta2Api.read_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -705,7 +705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling AutoscalingV2beta2Api.read_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -777,7 +777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta2Api.replace_namespaced_horizontal_pod_autoscaler"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -850,7 +850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling AutoscalingV2beta2Api.replace_namespaced_horizontal_pod_autoscaler_status"
       end
       # resource path
-      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/autoscaling/v2beta2/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/batch_api.rb
+++ b/kubernetes/lib/kubernetes/api/batch_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class BatchApi

--- a/kubernetes/lib/kubernetes/api/batch_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/batch_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class BatchV1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1Api.create_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1Api.delete_collection_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1Api.delete_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1Api.list_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1Api.patch_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -570,7 +570,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1Api.patch_namespaced_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -639,7 +639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1Api.read_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -705,7 +705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1Api.read_namespaced_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -777,7 +777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1Api.replace_namespaced_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -850,7 +850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1Api.replace_namespaced_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/batch_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/batch_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class BatchV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1beta1Api.create_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1beta1Api.delete_collection_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1beta1Api.delete_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1beta1Api.list_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1beta1Api.patch_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -570,7 +570,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1beta1Api.patch_namespaced_cron_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -639,7 +639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1beta1Api.read_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -705,7 +705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV1beta1Api.read_namespaced_cron_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -777,7 +777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1beta1Api.replace_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -850,7 +850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV1beta1Api.replace_namespaced_cron_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/batch_v2alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/batch_v2alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class BatchV2alpha1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV2alpha1Api.create_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV2alpha1Api.delete_collection_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV2alpha1Api.delete_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV2alpha1Api.list_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV2alpha1Api.patch_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -570,7 +570,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV2alpha1Api.patch_namespaced_cron_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -639,7 +639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV2alpha1Api.read_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -705,7 +705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling BatchV2alpha1Api.read_namespaced_cron_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -777,7 +777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV2alpha1Api.replace_namespaced_cron_job"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -850,7 +850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling BatchV2alpha1Api.replace_namespaced_cron_job_status"
       end
       # resource path
-      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/certificates_api.rb
+++ b/kubernetes/lib/kubernetes/api/certificates_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CertificatesApi

--- a/kubernetes/lib/kubernetes/api/certificates_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/certificates_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CertificatesV1beta1Api
@@ -120,7 +120,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CertificatesV1beta1Api.delete_certificate_signing_request"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CertificatesV1beta1Api.patch_certificate_signing_request"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -458,7 +458,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CertificatesV1beta1Api.patch_certificate_signing_request_status"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -521,7 +521,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CertificatesV1beta1Api.read_certificate_signing_request"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -581,7 +581,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CertificatesV1beta1Api.read_certificate_signing_request_status"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -647,7 +647,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CertificatesV1beta1Api.replace_certificate_signing_request"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -714,7 +714,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CertificatesV1beta1Api.replace_certificate_signing_request_approval"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/approval".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/approval".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -781,7 +781,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CertificatesV1beta1Api.replace_certificate_signing_request_status"
       end
       # resource path
-      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/certificates.k8s.io/v1beta1/certificatesigningrequests/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/coordination_api.rb
+++ b/kubernetes/lib/kubernetes/api/coordination_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CoordinationApi

--- a/kubernetes/lib/kubernetes/api/coordination_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/coordination_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CoordinationV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoordinationV1beta1Api.create_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoordinationV1beta1Api.delete_collection_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoordinationV1beta1Api.delete_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoordinationV1beta1Api.list_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoordinationV1beta1Api.patch_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -566,7 +566,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoordinationV1beta1Api.read_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -640,7 +640,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoordinationV1beta1Api.replace_namespaced_lease"
       end
       # resource path
-      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/coordination.k8s.io/v1beta1/namespaces/{namespace}/leases/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/core_api.rb
+++ b/kubernetes/lib/kubernetes/api/core_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CoreApi

--- a/kubernetes/lib/kubernetes/api/core_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/core_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CoreV1Api
@@ -52,7 +52,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_delete_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -122,7 +122,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_delete_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -186,7 +186,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_delete_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -256,7 +256,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_delete_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -314,7 +314,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_delete_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -378,7 +378,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_delete_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -450,7 +450,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_get_namespaced_pod_attach"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/attach".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/attach".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -528,7 +528,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_get_namespaced_pod_exec"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/exec".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/exec".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -597,7 +597,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_get_namespaced_pod_portforward"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/portforward".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/portforward".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -661,7 +661,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_get_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -731,7 +731,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_get_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -795,7 +795,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_get_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -865,7 +865,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_get_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -923,7 +923,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_get_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -987,7 +987,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_get_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1051,7 +1051,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_head_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1121,7 +1121,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_head_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1185,7 +1185,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_head_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1255,7 +1255,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_head_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1313,7 +1313,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_head_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1377,7 +1377,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_head_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1441,7 +1441,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_options_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1511,7 +1511,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_options_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1575,7 +1575,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_options_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1645,7 +1645,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_options_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1703,7 +1703,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_options_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1767,7 +1767,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_options_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1831,7 +1831,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_patch_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1901,7 +1901,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_patch_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -1965,7 +1965,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_patch_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2035,7 +2035,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_patch_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -2093,7 +2093,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_patch_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2157,7 +2157,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_patch_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -2229,7 +2229,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_post_namespaced_pod_attach"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/attach".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/attach".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2307,7 +2307,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_post_namespaced_pod_exec"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/exec".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/exec".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2376,7 +2376,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_post_namespaced_pod_portforward"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/portforward".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/portforward".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2440,7 +2440,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_post_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2510,7 +2510,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_post_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -2574,7 +2574,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_post_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2644,7 +2644,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_post_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -2702,7 +2702,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_post_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2766,7 +2766,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_post_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -2830,7 +2830,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_put_namespaced_pod_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2900,7 +2900,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_put_namespaced_pod_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -2964,7 +2964,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.connect_put_namespaced_service_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3034,7 +3034,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_put_namespaced_service_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -3092,7 +3092,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.connect_put_node_proxy"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -3156,7 +3156,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'path' when calling CoreV1Api.connect_put_node_proxy_with_path"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'path' + '}', path.to_s)
+      local_var_path = "/api/v1/nodes/{name}/proxy/{path}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'path' + '}', path.to_s)
 
       # query parameters
       query_params = {}
@@ -3288,7 +3288,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_binding"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/bindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/bindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3358,7 +3358,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3428,7 +3428,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3498,7 +3498,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3568,7 +3568,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3638,7 +3638,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3708,7 +3708,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3784,7 +3784,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_pod_binding"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/binding".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/binding".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3860,7 +3860,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_pod_eviction"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/eviction".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/eviction".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3930,7 +3930,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4000,7 +4000,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4070,7 +4070,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4140,7 +4140,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4210,7 +4210,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_service"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4280,7 +4280,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.create_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4484,7 +4484,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4566,7 +4566,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4648,7 +4648,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4730,7 +4730,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4812,7 +4812,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4894,7 +4894,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4976,7 +4976,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5058,7 +5058,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5140,7 +5140,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5222,7 +5222,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5304,7 +5304,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_collection_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5532,7 +5532,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.delete_namespace"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -5610,7 +5610,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5688,7 +5688,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5766,7 +5766,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5844,7 +5844,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5922,7 +5922,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6000,7 +6000,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6078,7 +6078,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6156,7 +6156,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6234,7 +6234,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6312,7 +6312,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6390,7 +6390,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_service"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6468,7 +6468,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.delete_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -6540,7 +6540,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.delete_node"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -6612,7 +6612,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.delete_persistent_volume"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -7195,7 +7195,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7277,7 +7277,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7359,7 +7359,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7441,7 +7441,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7523,7 +7523,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7605,7 +7605,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7687,7 +7687,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7769,7 +7769,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7851,7 +7851,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -7933,7 +7933,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -8015,7 +8015,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_service"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -8097,7 +8097,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.list_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -8931,7 +8931,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespace"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -8998,7 +8998,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespace_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -9071,7 +9071,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9144,7 +9144,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9217,7 +9217,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9290,7 +9290,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9363,7 +9363,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9436,7 +9436,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_persistent_volume_claim_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9509,7 +9509,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9582,7 +9582,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_pod_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9655,7 +9655,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9728,7 +9728,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9801,7 +9801,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_replication_controller_scale"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9874,7 +9874,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_replication_controller_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -9947,7 +9947,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10020,7 +10020,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_resource_quota_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10093,7 +10093,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10166,7 +10166,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_service"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10239,7 +10239,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10312,7 +10312,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_namespaced_service_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10379,7 +10379,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_node"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10446,7 +10446,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_node_status"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10513,7 +10513,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_persistent_volume"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10580,7 +10580,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.patch_persistent_volume_status"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10639,7 +10639,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_component_status"
       end
       # resource path
-      local_var_path = "/api/v1/componentstatuses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/componentstatuses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10701,7 +10701,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_namespace"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10761,7 +10761,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_namespace_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -10829,7 +10829,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10899,7 +10899,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -10969,7 +10969,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11039,7 +11039,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11109,7 +11109,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11175,7 +11175,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_persistent_volume_claim_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11243,7 +11243,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11323,7 +11323,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_pod_log"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/log".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/log".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11394,7 +11394,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_pod_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11462,7 +11462,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11532,7 +11532,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11598,7 +11598,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_replication_controller_scale"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11662,7 +11662,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_replication_controller_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11730,7 +11730,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11796,7 +11796,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_resource_quota_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11864,7 +11864,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -11934,7 +11934,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_service"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12004,7 +12004,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12070,7 +12070,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling CoreV1Api.read_namespaced_service_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12132,7 +12132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_node"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12192,7 +12192,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_node_status"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12254,7 +12254,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_persistent_volume"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12314,7 +12314,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CoreV1Api.read_persistent_volume_status"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12380,7 +12380,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespace"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12447,7 +12447,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespace_finalize"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}/finalize".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}/finalize".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12514,7 +12514,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespace_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/namespaces/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -12587,7 +12587,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_config_map"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/configmaps/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12660,7 +12660,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_endpoints"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/endpoints/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12733,7 +12733,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_event"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12806,7 +12806,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_limit_range"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/limitranges/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12879,7 +12879,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_persistent_volume_claim"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -12952,7 +12952,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_persistent_volume_claim_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13025,7 +13025,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_pod"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13098,7 +13098,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_pod_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/pods/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13171,7 +13171,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_pod_template"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/podtemplates/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13244,7 +13244,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_replication_controller"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13317,7 +13317,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_replication_controller_scale"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13390,7 +13390,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_replication_controller_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13463,7 +13463,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_resource_quota"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13536,7 +13536,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_resource_quota_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13609,7 +13609,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_secret"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/secrets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13682,7 +13682,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_service"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13755,7 +13755,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_service_account"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/serviceaccounts/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13828,7 +13828,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_namespaced_service_status"
       end
       # resource path
-      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/api/v1/namespaces/{namespace}/services/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -13895,7 +13895,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_node"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -13962,7 +13962,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_node_status"
       end
       # resource path
-      local_var_path = "/api/v1/nodes/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/nodes/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -14029,7 +14029,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_persistent_volume"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -14096,7 +14096,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CoreV1Api.replace_persistent_volume_status"
       end
       # resource path
-      local_var_path = "/api/v1/persistentvolumes/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/api/v1/persistentvolumes/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/custom_objects_api.rb
+++ b/kubernetes/lib/kubernetes/api/custom_objects_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class CustomObjectsApi
@@ -144,7 +144,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.create_namespaced_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s)
 
       # query parameters
       query_params = {}
@@ -228,7 +228,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.delete_cluster_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -322,7 +322,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.delete_namespaced_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -398,7 +398,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CustomObjectsApi.get_cluster_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -471,7 +471,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CustomObjectsApi.get_cluster_custom_object_scale"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -544,7 +544,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CustomObjectsApi.get_cluster_custom_object_status"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -623,7 +623,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CustomObjectsApi.get_namespaced_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -702,7 +702,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CustomObjectsApi.get_namespaced_custom_object_scale"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -781,7 +781,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling CustomObjectsApi.get_namespaced_custom_object_status"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -946,7 +946,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'plural' when calling CustomObjectsApi.list_namespaced_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s)
 
       # query parameters
       query_params = {}
@@ -1030,7 +1030,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.patch_cluster_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1109,7 +1109,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.patch_cluster_custom_object_scale"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1188,7 +1188,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.patch_cluster_custom_object_status"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1273,7 +1273,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.patch_namespaced_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1358,7 +1358,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.patch_namespaced_custom_object_scale"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1443,7 +1443,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.patch_namespaced_custom_object_status"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1522,7 +1522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.replace_cluster_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1601,7 +1601,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.replace_cluster_custom_object_scale"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1680,7 +1680,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.replace_cluster_custom_object_status"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1765,7 +1765,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.replace_namespaced_custom_object"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1850,7 +1850,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.replace_namespaced_custom_object_scale"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/scale".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1935,7 +1935,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling CustomObjectsApi.replace_namespaced_custom_object_status"
       end
       # resource path
-      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', namespace.to_s).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}/status".sub('{' + 'group' + '}', group.to_s).sub('{' + 'version' + '}', version.to_s).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s)).sub('{' + 'plural' + '}', plural.to_s).sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/events_api.rb
+++ b/kubernetes/lib/kubernetes/api/events_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class EventsApi

--- a/kubernetes/lib/kubernetes/api/events_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/events_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class EventsV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling EventsV1beta1Api.create_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling EventsV1beta1Api.delete_collection_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling EventsV1beta1Api.delete_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -417,7 +417,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling EventsV1beta1Api.list_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling EventsV1beta1Api.patch_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -566,7 +566,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling EventsV1beta1Api.read_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -640,7 +640,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling EventsV1beta1Api.replace_namespaced_event"
       end
       # resource path
-      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/events.k8s.io/v1beta1/namespaces/{namespace}/events/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/extensions_api.rb
+++ b/kubernetes/lib/kubernetes/api/extensions_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ExtensionsApi

--- a/kubernetes/lib/kubernetes/api/extensions_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/extensions_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class ExtensionsV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.create_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -126,7 +126,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.create_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -202,7 +202,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.create_namespaced_deployment_rollback"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -272,7 +272,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.create_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -342,7 +342,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.create_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -412,7 +412,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.create_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -552,7 +552,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_collection_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -634,7 +634,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_collection_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -716,7 +716,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_collection_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -798,7 +798,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_collection_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -880,7 +880,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_collection_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1038,7 +1038,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1116,7 +1116,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1194,7 +1194,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1272,7 +1272,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1350,7 +1350,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.delete_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1422,7 +1422,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ExtensionsV1beta1Api.delete_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1777,7 +1777,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.list_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1859,7 +1859,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.list_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1941,7 +1941,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.list_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2023,7 +2023,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.list_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2105,7 +2105,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.list_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2413,7 +2413,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2486,7 +2486,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2559,7 +2559,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2632,7 +2632,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2705,7 +2705,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2778,7 +2778,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2851,7 +2851,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_ingress_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2924,7 +2924,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2997,7 +2997,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3070,7 +3070,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3143,7 +3143,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3216,7 +3216,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_namespaced_replication_controller_dummy_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3283,7 +3283,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.patch_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -3352,7 +3352,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3418,7 +3418,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3486,7 +3486,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3552,7 +3552,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3616,7 +3616,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3684,7 +3684,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3750,7 +3750,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_ingress_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3818,7 +3818,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3888,7 +3888,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -3954,7 +3954,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4018,7 +4018,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4082,7 +4082,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling ExtensionsV1beta1Api.read_namespaced_replication_controller_dummy_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4144,7 +4144,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling ExtensionsV1beta1Api.read_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -4218,7 +4218,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_daemon_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4291,7 +4291,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_daemon_set_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4364,7 +4364,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_deployment"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4437,7 +4437,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_deployment_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4510,7 +4510,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_deployment_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4583,7 +4583,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_ingress"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4656,7 +4656,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_ingress_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4729,7 +4729,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4802,7 +4802,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_replica_set"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4875,7 +4875,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_replica_set_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -4948,7 +4948,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_replica_set_status"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5021,7 +5021,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_namespaced_replication_controller_dummy_scale"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -5088,7 +5088,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling ExtensionsV1beta1Api.replace_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/extensions/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/logs_api.rb
+++ b/kubernetes/lib/kubernetes/api/logs_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class LogsApi

--- a/kubernetes/lib/kubernetes/api/networking_api.rb
+++ b/kubernetes/lib/kubernetes/api/networking_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class NetworkingApi

--- a/kubernetes/lib/kubernetes/api/networking_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/networking_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class NetworkingV1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling NetworkingV1Api.create_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling NetworkingV1Api.delete_collection_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling NetworkingV1Api.delete_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -341,7 +341,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling NetworkingV1Api.list_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling NetworkingV1Api.patch_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -566,7 +566,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling NetworkingV1Api.read_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -640,7 +640,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling NetworkingV1Api.replace_namespaced_network_policy"
       end
       # resource path
-      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/networking.k8s.io/v1/namespaces/{namespace}/networkpolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/policy_api.rb
+++ b/kubernetes/lib/kubernetes/api/policy_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class PolicyApi

--- a/kubernetes/lib/kubernetes/api/policy_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/policy_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class PolicyV1beta1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.create_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling PolicyV1beta1Api.delete_collection_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -354,7 +354,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling PolicyV1beta1Api.delete_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -426,7 +426,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling PolicyV1beta1Api.delete_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -553,7 +553,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling PolicyV1beta1Api.list_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -785,7 +785,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.patch_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -858,7 +858,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.patch_namespaced_pod_disruption_budget_status"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -925,7 +925,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.patch_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -994,7 +994,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling PolicyV1beta1Api.read_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1060,7 +1060,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling PolicyV1beta1Api.read_namespaced_pod_disruption_budget_status"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1122,7 +1122,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling PolicyV1beta1Api.read_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1196,7 +1196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.replace_namespaced_pod_disruption_budget"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1269,7 +1269,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.replace_namespaced_pod_disruption_budget_status"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1336,7 +1336,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling PolicyV1beta1Api.replace_pod_security_policy"
       end
       # resource path
-      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/policy/v1beta1/podsecuritypolicies/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/rbac_authorization_api.rb
+++ b/kubernetes/lib/kubernetes/api/rbac_authorization_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class RbacAuthorizationApi

--- a/kubernetes/lib/kubernetes/api/rbac_authorization_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/rbac_authorization_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class RbacAuthorizationV1Api
@@ -184,7 +184,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.create_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -254,7 +254,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.create_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -324,7 +324,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1Api.delete_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -396,7 +396,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1Api.delete_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -626,7 +626,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.delete_collection_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -708,7 +708,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.delete_collection_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -790,7 +790,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.delete_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -868,7 +868,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.delete_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1147,7 +1147,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.list_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1229,7 +1229,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.list_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1455,7 +1455,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.patch_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1522,7 +1522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.patch_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1595,7 +1595,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.patch_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1668,7 +1668,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.patch_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1727,7 +1727,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1Api.read_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1785,7 +1785,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1Api.read_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1849,7 +1849,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.read_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1913,7 +1913,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1Api.read_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1979,7 +1979,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.replace_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2046,7 +2046,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.replace_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2119,7 +2119,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.replace_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2192,7 +2192,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1Api.replace_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/rbac_authorization_v1alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/rbac_authorization_v1alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class RbacAuthorizationV1alpha1Api
@@ -184,7 +184,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.create_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -254,7 +254,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.create_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -324,7 +324,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1alpha1Api.delete_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -396,7 +396,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1alpha1Api.delete_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -626,7 +626,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.delete_collection_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -708,7 +708,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.delete_collection_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -790,7 +790,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.delete_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -868,7 +868,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.delete_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1147,7 +1147,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.list_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1229,7 +1229,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.list_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1455,7 +1455,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.patch_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1522,7 +1522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.patch_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1595,7 +1595,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.patch_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1668,7 +1668,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.patch_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1727,7 +1727,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1alpha1Api.read_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1785,7 +1785,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1alpha1Api.read_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1849,7 +1849,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.read_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1913,7 +1913,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1alpha1Api.read_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1979,7 +1979,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.replace_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2046,7 +2046,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.replace_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2119,7 +2119,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.replace_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2192,7 +2192,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1alpha1Api.replace_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/rbac_authorization_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/rbac_authorization_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class RbacAuthorizationV1beta1Api
@@ -184,7 +184,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.create_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -254,7 +254,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.create_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -324,7 +324,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1beta1Api.delete_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -396,7 +396,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1beta1Api.delete_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -626,7 +626,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.delete_collection_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -708,7 +708,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.delete_collection_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -790,7 +790,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.delete_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -868,7 +868,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.delete_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1147,7 +1147,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.list_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1229,7 +1229,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.list_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1455,7 +1455,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.patch_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1522,7 +1522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.patch_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1595,7 +1595,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.patch_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1668,7 +1668,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.patch_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1727,7 +1727,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1beta1Api.read_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1785,7 +1785,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling RbacAuthorizationV1beta1Api.read_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1849,7 +1849,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.read_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1913,7 +1913,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling RbacAuthorizationV1beta1Api.read_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -1979,7 +1979,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.replace_cluster_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterroles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2046,7 +2046,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.replace_cluster_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -2119,7 +2119,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.replace_namespaced_role"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/roles/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -2192,7 +2192,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling RbacAuthorizationV1beta1Api.replace_namespaced_role_binding"
       end
       # resource path
-      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/rbac.authorization.k8s.io/v1beta1/namespaces/{namespace}/rolebindings/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/scheduling_api.rb
+++ b/kubernetes/lib/kubernetes/api/scheduling_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class SchedulingApi

--- a/kubernetes/lib/kubernetes/api/scheduling_v1alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/scheduling_v1alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class SchedulingV1alpha1Api
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling SchedulingV1alpha1Api.delete_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SchedulingV1alpha1Api.patch_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -454,7 +454,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling SchedulingV1alpha1Api.read_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -522,7 +522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SchedulingV1alpha1Api.replace_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/scheduling_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/scheduling_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class SchedulingV1beta1Api
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling SchedulingV1beta1Api.delete_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SchedulingV1beta1Api.patch_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -454,7 +454,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling SchedulingV1beta1Api.read_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -522,7 +522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SchedulingV1beta1Api.replace_priority_class"
       end
       # resource path
-      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/scheduling.k8s.io/v1beta1/priorityclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/settings_api.rb
+++ b/kubernetes/lib/kubernetes/api/settings_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class SettingsApi

--- a/kubernetes/lib/kubernetes/api/settings_v1alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/settings_v1alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class SettingsV1alpha1Api
@@ -56,7 +56,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SettingsV1alpha1Api.create_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -132,7 +132,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling SettingsV1alpha1Api.delete_collection_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -214,7 +214,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling SettingsV1alpha1Api.delete_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -341,7 +341,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling SettingsV1alpha1Api.list_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets".sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets".sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -497,7 +497,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SettingsV1alpha1Api.patch_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -566,7 +566,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'namespace' when calling SettingsV1alpha1Api.read_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}
@@ -640,7 +640,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling SettingsV1alpha1Api.replace_namespaced_pod_preset"
       end
       # resource path
-      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', name.to_s).sub('{' + 'namespace' + '}', namespace.to_s)
+      local_var_path = "/apis/settings.k8s.io/v1alpha1/namespaces/{namespace}/podpresets/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s)).sub('{' + 'namespace' + '}', CGI.escape(namespace.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/storage_api.rb
+++ b/kubernetes/lib/kubernetes/api/storage_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class StorageApi

--- a/kubernetes/lib/kubernetes/api/storage_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/storage_v1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class StorageV1Api
@@ -336,7 +336,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1Api.delete_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -408,7 +408,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1Api.delete_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -679,7 +679,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1Api.patch_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -746,7 +746,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1Api.patch_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -813,7 +813,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1Api.patch_volume_attachment_status"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -876,7 +876,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1Api.read_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -940,7 +940,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1Api.read_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1000,7 +1000,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1Api.read_volume_attachment_status"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1066,7 +1066,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1Api.replace_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1133,7 +1133,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1Api.replace_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1200,7 +1200,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1Api.replace_volume_attachment_status"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}/status".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1/volumeattachments/{name}/status".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/storage_v1alpha1_api.rb
+++ b/kubernetes/lib/kubernetes/api/storage_v1alpha1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class StorageV1alpha1Api
@@ -196,7 +196,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1alpha1Api.delete_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -391,7 +391,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1alpha1Api.patch_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -454,7 +454,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1alpha1Api.read_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -522,7 +522,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1alpha1Api.replace_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1alpha1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/storage_v1beta1_api.rb
+++ b/kubernetes/lib/kubernetes/api/storage_v1beta1_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class StorageV1beta1Api
@@ -336,7 +336,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1beta1Api.delete_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -408,7 +408,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1beta1Api.delete_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -679,7 +679,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1beta1Api.patch_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -746,7 +746,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1beta1Api.patch_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -809,7 +809,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1beta1Api.read_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -873,7 +873,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'name' when calling StorageV1beta1Api.read_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -941,7 +941,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1beta1Api.replace_storage_class"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/storageclasses/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}
@@ -1008,7 +1008,7 @@ module Kubernetes
         fail ArgumentError, "Missing the required parameter 'body' when calling StorageV1beta1Api.replace_volume_attachment"
       end
       # resource path
-      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', name.to_s)
+      local_var_path = "/apis/storage.k8s.io/v1beta1/volumeattachments/{name}".sub('{' + 'name' + '}', CGI.escape(name.to_s))
 
       # query parameters
       query_params = {}

--- a/kubernetes/lib/kubernetes/api/version_api.rb
+++ b/kubernetes/lib/kubernetes/api/version_api.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require "uri"
+require "cgi"
 
 module Kubernetes
   class VersionApi

--- a/kubernetes/lib/kubernetes/api_client.rb
+++ b/kubernetes/lib/kubernetes/api_client.rb
@@ -15,7 +15,6 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
 
 module Kubernetes
   class ApiClient
@@ -264,7 +263,7 @@ module Kubernetes
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      @config.base_url + path
     end
 
     # Builds the HTTP request body

--- a/kubernetes/lib/kubernetes/configuration.rb
+++ b/kubernetes/lib/kubernetes/configuration.rb
@@ -10,8 +10,6 @@ Swagger Codegen version: 2.2.3
 
 =end
 
-require 'uri'
-
 module Kubernetes
   class Configuration
     # Defines url scheme
@@ -174,8 +172,7 @@ module Kubernetes
     end
 
     def base_url
-      url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
- `URI.escape` is obsolete
  - URL paths should be escaped by each definition
- Some gems does not match Ruby 3

# What I did
- remove URI.escape and escape paths: https://github.com/primenumber-dev/kubernetes-client-ruby/pull/4/commits/fd816275364ae6386667c1e930d20f3a1361cd61
- bump up ffi, json, rexml for Ruby 3: https://github.com/primenumber-dev/kubernetes-client-ruby/pull/4/commits/3130717c11fff744a21b4a4bf00b46f8f1eb7131