### PR TITLE
try_refresh_token to false

### DIFF
--- a/kubernetes/src/kubernetes/config/incluster_config.rb
+++ b/kubernetes/src/kubernetes/config/incluster_config.rb
@@ -78,7 +78,7 @@ module Kubernetes
     end
 
     # rubocop:disable Metrics/AbcSize
-    def configure(configuration, try_refresh_token: true)
+    def configure(configuration, try_refresh_token: false)
       validate
       load_token
       configuration.api_key['authorization'] = "Bearer #{token}"


### PR DESCRIPTION
# What I did
- set `try_refresh_token` of `Kubernetes::InClusterConfig` to `false`
  - this is original behavior: https://github.com/primenumber-dev/kubernetes-client-ruby/compare/9ce198e916e2c3b58d952f7e9f7e36a6bedc52ee...33861097e2eab9954b3f07f6898e5e8199199731#diff-2a9c948bfcac52305255f39a7b38d20ffdf11ea5fa91be2579f70fdad5064d5dR90-R103